### PR TITLE
Add status code to json response

### DIFF
--- a/src/APIResponse.php
+++ b/src/APIResponse.php
@@ -26,11 +26,13 @@ class APIResponse
      */
     public function response($status, $message, $data)
     {
-        return response()->json([
+        $json = [
             $this->statusLabel  => config('api.stringify') ? strval($status) : $status,
             $this->messageLabel => $message,
             $this->dataLabel    => $data,
-        ], $status);
+        ];
+
+        return (config('api.matchstatus')) ? response()->json($json, $status) : response()->json($json);
     }
 
     /**

--- a/src/APIResponse.php
+++ b/src/APIResponse.php
@@ -30,7 +30,7 @@ class APIResponse
             $this->statusLabel  => config('api.stringify') ? strval($status) : $status,
             $this->messageLabel => $message,
             $this->dataLabel    => $data,
-        ]);
+        ], $status);
     }
 
     /**

--- a/src/config/api.php
+++ b/src/config/api.php
@@ -2,18 +2,18 @@
 
 return [
 
-    /**
+    /*
      * Turn to string the status code in the json response's body.
      */
     'stringify' => true,
 
-    /**
+    /*
      * Set the status code from the json response to be the same as the status code
      * in the json response's body.
      */
     'matchstatus' => false,
 
-    /**
+    /*
      * Json response's body labels.
      */
     'keys'      => [
@@ -22,7 +22,7 @@ return [
         'data'    => 'DATA',
     ],
 
-    /**
+    /*
      * Default included status codes.
      */
     'codes' => [
@@ -32,7 +32,7 @@ return [
         'error'      => 500,
     ],
 
-    /**
+    /*
      * Status codes default messages.
      */
     'messages' => [

--- a/src/config/api.php
+++ b/src/config/api.php
@@ -2,18 +2,39 @@
 
 return [
 
+    /**
+     * Turn to string the status code in the json response's body.
+     */
     'stringify' => true,
+
+    /**
+     * Set the status code from the json response to be the same as the status code
+     * in the json response's body.
+     */
+    'matchstatus' => false,
+
+    /**
+     * Json response's body labels.
+     */
     'keys'      => [
         'status'  => 'STATUS',
         'message' => 'MESSAGE',
         'data'    => 'DATA',
     ],
+
+    /**
+     * Default included status codes.
+     */
     'codes' => [
         'success'    => 200,
         'notfound'   => 404,
         'validation' => 402,
         'error'      => 500,
     ],
+
+    /**
+     * Status codes default messages.
+     */
     'messages' => [
         'success'    => 'Process is successfully completed',
         'notfound'   => 'Sorry no results query for your request.',


### PR DESCRIPTION
Tested with postman.
If:
`return api()->response(418, 'I am a teapot', '');`
then the http response will have the status code like `200 OK` and the response body will contain (as expected):
```
{
    "STATUS": "418",
    "MESSAGE": "I am a teapot",
    "DATA": ""
}
```

with the new addition, the status http response status code will be `418 I'm a teapot` and the response body will be the same.
