### PR TITLE
Add support for extra data passed thru the response function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .idea
+.phpunit.result.cache

--- a/src/APIResponse.php
+++ b/src/APIResponse.php
@@ -24,13 +24,19 @@ class APIResponse
      *
      * @return JsonResponse
      */
-    public function response($status, $message, $data)
+    public function response($status, $message, $data, ...$extraData)
     {
         $json = [
             $this->statusLabel  => config('api.stringify') ? strval($status) : $status,
             $this->messageLabel => $message,
             $this->dataLabel    => $data,
         ];
+
+        if ($extraData) {
+            foreach ($extraData as $extra) {
+                $json = array_merge($json, $extra);
+            }
+        }
 
         return (config('api.matchstatus')) ? response()->json($json, $status) : response()->json($json);
     }

--- a/src/APIResponse.php
+++ b/src/APIResponse.php
@@ -47,13 +47,13 @@ class APIResponse
      *
      * @return JsonResponse
      */
-    public function ok($message = '', $data = [])
+    public function ok($message = '', $data = [], ...$extraData)
     {
         if (empty($message)) {
             $message = config('api.messages.success');
         }
 
-        return $this->response(config('api.codes.success'), $message, $data);
+        return $this->response(config('api.codes.success'), $message, $data, ...$extraData);
     }
 
     /**
@@ -76,13 +76,13 @@ class APIResponse
      *
      * @return JsonResponse
      */
-    public function validation($message = '', $errors = [])
+    public function validation($message = '', $errors = [], ...$extraData)
     {
         if (empty($message)) {
             $message = config('api.messages.validation');
         }
 
-        return $this->response(config('api.codes.validation'), $message, $errors);
+        return $this->response(config('api.codes.validation'), $message, $errors, ...$extraData);
     }
 
     /**
@@ -91,17 +91,17 @@ class APIResponse
      *
      * @return JsonResponse
      */
-    public function validationFailedWithMessage($message, $errors)
+    public function validationFailedWithMessage($message, $errors, ...$extraData)
     {
-        return $this->response(422, $message, $errors);
+        return $this->response(422, $message, $errors, ...$extraData);
     }
 
-    public function error($message = '', $data = [])
+    public function error($message = '', $data = [], ...$extraData)
     {
         if (empty($message)) {
             $message = config('api.messages.error');
         }
 
-        return $this->response(config('api.codes.error'), $message, $data);
+        return $this->response(config('api.codes.error'), $message, $data, ...$extraData);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
-//if (! function_exists('api')){
+if (!function_exists('api')) {
+
     /**
      * Create a new APIResponse instance.
      *
@@ -10,12 +11,12 @@
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    function api($status = 200, $message = '', $data = [])
+    function api($status = 200, $message = '', $data = [], ...$extraData)
     {
         if (func_num_args() === 0) {
             return app('api');
         }
 
-        return app('api')->response($status, $message, $data);
+        return app('api')->response($status, $message, $data, ...$extraData);
     }
-//}
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -65,5 +65,51 @@ class ResponseTest extends TestCase
         $this->assertEquals($expectedResponse, json_decode($response, 1));
     }
 
+    /** @test */
+    public function it_returns_extra_parameters()
+    {
+        // using the api()->response()
+        $response = api()->response(200,
+            'New Response',
+            ['name'      => 'Joe Doe'],
+            ['code'      => 30566],
+            ['reference' => 'ERROR-2019-09-14']
+        )->getContent();
+        $expectedResponse = [
+            'STATUS'    => 200,
+            'MESSAGE'   => 'New Response',
+            'DATA'      => ['name' => 'Joe Doe'],
+            'code'      => 30566,
+            'reference' => 'ERROR-2019-09-14',
+        ];
+        $this->assertEquals($expectedResponse, json_decode($response, 1));
+
+        // using the facade
+        $response = API::response(200,
+            'New Response',
+            ['name'      => 'Joe Doe'],
+            ['code'      => 30566],
+            ['reference' => 'ERROR-2019-09-14']
+        )->getContent();
+        $this->assertEquals($expectedResponse, json_decode($response, 1));
+
+        // using api() directly
+        $response = api(200,
+            'New Response',
+            ['name'      => 'Joe Doe'],
+            ['code'      => 30566],
+            ['reference' => 'ERROR-2019-09-14']
+        )->getContent();
+        $this->assertEquals($expectedResponse, json_decode($response, 1));
+
+        // extra data as part of the same array
+        $response = api()->response(200,
+            'New Response',
+            ['name'      => 'Joe Doe'],
+            ['code'      => 30566, 'reference' => 'ERROR-2019-09-14']
+        )->getContent();
+        $this->assertEquals($expectedResponse, json_decode($response, 1));
+    }
+
     // TODO (3 test): test validation errors, default message validation, serer error response
 }


### PR DESCRIPTION
The extra data can be added as a single array or as many arrays.
The extra data is recommended to be added as an array otherwise it will be added as `0 => data, 1 => data`.

Let me know if this works for you and if I can proceed to add the new feature to the rest of the responses functions such as ok(), validation(), etc

Cheers