### PR TITLE
Change API Service Provider Name for Registering package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Simple Laravel API response wrapper.
 
 2. Register the package service provider to the providers array in `app.php` file:
 
-    `Obiefy\API\APIServiceProvider::class`
+    `Obiefy\API\ApiResponseServiceProvider::class`
 
 3. Register the package facade alias to the aliases array in `app.php` file:
 


### PR DESCRIPTION
in step 2 wrong class name used 
it used `APIServiceProvider `but it does no exists in vendor folder existing class name is `ApiResponseServiceProvider`

https://github.com/obiefy/api-response/issues/40#issue-703073589
check this issue