### PR TITLE
Move messages to translation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ If you need to customize the default messages or the json response labels, you c
 
 |method| default status code  | change code |  message  |
 |--|--| -- | --- |
-|`ok()`|  200 |`config('api.codes.success)` | `config('api.messages.success)`
-|`notFound()`|  404 |`config('api.codes.notfound)` | `config('api.messages.notfound)`
-|`validation()`|  422 |`config('api.codes.validation)` | `config('api.messages.validation)`
-|`error()`|  500 |`config('api.codes.error)` | `config('api.messages.error)`
+|`ok()`|  200 |`config('api.codes.success)` | `trans('api-response::messages.success)`
+|`notFound()`|  404 |`config('api.codes.notfound)` | `trans('api-response::messages.notfound)`
+|`validation()`|  422 |`config('api.codes.validation)` | `trans('api-response::messages.validation)`
+|`error()`|  500 |`config('api.codes.error)` | `trans('api-response::messages.error)`
 
 ### Matching Status Codes
 By default, all API responses return a 200 OK HTTP status header. If you'd like the status header to match the Response's status, set the `matchstatus` configuration to `true`

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/support": "^8.0|^7.0|^6.0|^5.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.5",
         "orchestra/testbench": "^6.0"
     },
     "autoload": {

--- a/config/api.php
+++ b/config/api.php
@@ -28,15 +28,4 @@ return [
         'data_count' => 'DATA_COUNT',
     ],
 
-    /*
-     * Response default messages.
-     */
-    'messages' => [
-        'success'    => 'Process is successfully completed',
-        'notfound'   => 'Sorry no results query for your request.',
-        'validation' => 'Validation Failed please check the request attributes and try again.',
-        'forbidden'  => 'You don\'t have permission to access this content.',
-        'error'      => 'Server error, please try again later',
-    ],
-
 ];

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'success'    => 'Process is successfully completed',
+    'notfound'   => 'Sorry no results query for your request.',
+    'validation' => 'Validation Failed please check the request attributes and try again.',
+    'forbidden'  => 'You don\'t have permission to access this content.',
+    'error'      => 'Server error, please try again later',
+];

--- a/src/ApiResponse.php
+++ b/src/ApiResponse.php
@@ -59,7 +59,7 @@ class ApiResponse implements ApiInterface
     public function ok($message = null, $data = [], ...$extraData)
     {
         if (is_null($message)) {
-            $message = trans('api-response::api.messages.success');
+            $message = trans('api-response::messages.success');
         }
 
         return $this->response(static::HTTP_OK, $message, $data, ...$extraData);

--- a/src/ApiResponse.php
+++ b/src/ApiResponse.php
@@ -59,7 +59,7 @@ class ApiResponse implements ApiInterface
     public function ok($message = null, $data = [], ...$extraData)
     {
         if (is_null($message)) {
-            $message = config('api.messages.success');
+            $message = trans('api-response::api.messages.success');
         }
 
         return $this->response(static::HTTP_OK, $message, $data, ...$extraData);
@@ -89,7 +89,7 @@ class ApiResponse implements ApiInterface
     public function notFound($message = null)
     {
         if (is_null($message)) {
-            $message = config('api.messages.notfound');
+            $message = trans('api-response::messages.notfound');
         }
 
         return $this->response(static::HTTP_NOT_FOUND, $message, []);
@@ -107,7 +107,7 @@ class ApiResponse implements ApiInterface
     public function validation($message = null, $errors = [], ...$extraData)
     {
         if (is_null($message)) {
-            $message = config('api.messages.validation');
+            $message = trans('api-response::messages.validation');
         }
 
         return $this->response(static::HTTP_UNPROCESSABLE_ENTITY, $message, $errors, ...$extraData);
@@ -125,7 +125,7 @@ class ApiResponse implements ApiInterface
     public function forbidden($message = null, $data = [], ...$extraData)
     {
         if (is_null($message)) {
-            $message = config('api.messages.forbidden');
+            $message = trans('api-response::messages.forbidden');
         }
 
         return $this->response(static::HTTP_FORBIDDEN, $message, $data, ...$extraData);
@@ -143,7 +143,7 @@ class ApiResponse implements ApiInterface
     public function error($message = null, $data = [], ...$extraData)
     {
         if (is_null($message)) {
-            $message = config('api.messages.error');
+            $message = trans('api-response::messages.error');
         }
 
         return $this->response(static::HTTP_INTERNAL_SERVER_ERROR, $message, $data, ...$extraData);

--- a/src/ApiResponseServiceProvider.php
+++ b/src/ApiResponseServiceProvider.php
@@ -59,5 +59,9 @@ class ApiResponseServiceProvider extends ServiceProvider
     private function setupTranslations()
     {
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'api-response');
+
+        $this->publishes([
+            __DIR__.'/../lang' => $this->app->langPath('vendor/api-response'),
+        ]);
     }
 }

--- a/src/ApiResponseServiceProvider.php
+++ b/src/ApiResponseServiceProvider.php
@@ -28,6 +28,8 @@ class ApiResponseServiceProvider extends ServiceProvider
     {
         $this->setupConfig();
 
+        $this->setupTranslations();
+
         $this->registerHelpers();
 
         $this->publishes([
@@ -52,5 +54,10 @@ class ApiResponseServiceProvider extends ServiceProvider
         if (file_exists($helperFile = __DIR__.'/helpers.php')) {
             require_once $helperFile;
         }
+    }
+
+    private function setupTranslations()
+    {
+        $this->loadTranslationsFrom(__DIR__.'/../lang', 'api-response');
     }
 }

--- a/tests/ErrorResponseTest.php
+++ b/tests/ErrorResponseTest.php
@@ -10,7 +10,7 @@ class ErrorResponseTest extends TestCase
         $response = api()->error()->getContent();
         $expectedResponse = [
             'STATUS'  => 500,
-            'MESSAGE' => config('api.messages.error'),
+            'MESSAGE' => trans('api-response::messages.error'),
             'DATA'    => [],
         ];
         $this->assertEquals($expectedResponse, json_decode($response, 1));

--- a/tests/ForbiddenResponseTest.php
+++ b/tests/ForbiddenResponseTest.php
@@ -10,7 +10,7 @@ class ForbiddenResponseTest extends TestCase
         $response = api()->forbidden()->getContent();
         $expectedResponse = [
             'STATUS'  => 403,
-            'MESSAGE' => config('api.messages.forbidden'),
+            'MESSAGE' => trans('api-response::messages.forbidden'),
             'DATA'    => [],
         ];
         $this->assertEquals($expectedResponse, json_decode($response, 1));

--- a/tests/NotFoundResponseTest.php
+++ b/tests/NotFoundResponseTest.php
@@ -24,7 +24,7 @@ class NotFoundResponseTest extends TestCase
     {
         $response = api()->notFound()->getContent();
         $expectedResponse = [
-            'MESSAGE' => config('api.messages.notfound'),
+            'MESSAGE' => trans('api-response::messages.notfound'),
             'STATUS'  => 404,
             'DATA'    => [],
         ];

--- a/tests/OkResponseTest.php
+++ b/tests/OkResponseTest.php
@@ -72,7 +72,7 @@ class OkResponseTest extends TestCase
     {
         $response = api()->ok()->getContent();
         $expectedResponse = [
-            'MESSAGE' => config('api.messages.success'),
+            'MESSAGE' => trans('api-response::messages.success'),
             'STATUS'  => 200,
             'DATA'    => [],
         ];

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -39,7 +39,7 @@ class ResponseTest extends TestCase
         $response = api()->ok()->getContent();
         $expectedResponse = [
             'newStatus'  => 200,
-            'newMessage' => config('api.messages.success'),
+            'newMessage' => trans('api-response::messages.success'),
             'newData'    => [],
         ];
         $this->assertEquals($expectedResponse, json_decode($response, 1));

--- a/tests/ValidationResponseTest.php
+++ b/tests/ValidationResponseTest.php
@@ -35,7 +35,7 @@ class ValidationResponseTest extends TestCase
         $response = api()->validation()->getContent();
         $expectedResponse = [
             'STATUS'  => 422,
-            'MESSAGE' => config('api.messages.validation'),
+            'MESSAGE' => trans('api-response::messages.validation'),
             'DATA'    => [],
         ];
 


### PR DESCRIPTION
In order to have a clean structure for messages, I though it may be a good idea to move all available default messages to a better place like Laravel languages and give the ability to user so as to customize them.

All tests are passed.